### PR TITLE
remove nodejs in provisionning

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,9 +10,6 @@
 - src: geerlingguy.java
   version: 1.1.0
 
-- src: JasonGiedymin.nodejs
-  version: master
-
 - src: kosssi.composer
   version: master
 

--- a/roles/web/meta/main.yml
+++ b/roles/web/meta/main.yml
@@ -1,5 +1,4 @@
 ---
 dependencies:
   - { role: common }
-  - { role: JasonGiedymin.nodejs }
   - { role: geerlingguy.varnish}

--- a/roles/web/tasks/node.yml
+++ b/roles/web/tasks/node.yml
@@ -1,5 +1,0 @@
----
- - name: ensure npm is installed
-   apt: pkg=npm state=latest
- - name: Create symbolic link for node
-   file: src=/usr/bin/nodejs dest=/usr/bin/node state=link


### PR DESCRIPTION
[OO-MISC] Suppression of install of nodeJS by the provisioning, it is now installed by `composer-extra-assets`. use now `./bin/grunt` for grunt and not `./node_modules/.bin/grunt`
